### PR TITLE
Resolve github actions deprecations messages.

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -14,7 +14,7 @@ jobs:
 
       # Checkout the branch
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: MFCR data
         run: bin/mfcr.sh
@@ -45,12 +45,12 @@ jobs:
 
       - name: get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
       - name: GIT commit
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "<>"
           git add -A
-          git commit -m "daily commit ${{ steps.date.outputs.date }}" || true
+          git commit -m "daily commit ${{ env.date }}" || true
           git push origin master || true


### PR DESCRIPTION
- Node.js 16 actions are deprecated. - actions/checkout@v3
- The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files.

Cheers!